### PR TITLE
Update Vehicle Locations Use Case to Accept dirTag Parameter

### DIFF
--- a/backend/src/main/java/com/example/backend/interface_adapters/VehicleLocationsController.java
+++ b/backend/src/main/java/com/example/backend/interface_adapters/VehicleLocationsController.java
@@ -15,8 +15,8 @@ public class VehicleLocationsController {
     private VehicleLocationsService vehicleLocationsImplementation;
 
     @PostMapping("/vehicle-locations")
-    public VehicleLocationsOutputData execute(@RequestParam String routeTag) {
-        return vehicleLocationsImplementation.execute(routeTag);
+    public VehicleLocationsOutputData execute(@RequestParam String routeTag, @RequestParam String dirTag) {
+        return vehicleLocationsImplementation.execute(routeTag, dirTag);
     }
 
 }

--- a/backend/src/main/java/com/example/backend/use_case/vehicle_locations/VehicleLocationsImplementation.java
+++ b/backend/src/main/java/com/example/backend/use_case/vehicle_locations/VehicleLocationsImplementation.java
@@ -1,15 +1,27 @@
 package com.example.backend.use_case.vehicle_locations;
 
 import com.example.backend.data_access.vehicle.VehicleDataAccessInterface;
+import com.example.backend.entity.Vehicle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
 
 @Service
 public class VehicleLocationsImplementation implements VehicleLocationsService {
     @Autowired
     VehicleDataAccessInterface vehicleDAO;
 
-    public VehicleLocationsOutputData execute(String routeTag) {
-        return new VehicleLocationsOutputData(vehicleDAO.getVehiclesByRouteTag(routeTag));
+    public VehicleLocationsOutputData execute(String routeTag, String dirTag) {
+        ArrayList<Vehicle> routeVehicles = vehicleDAO.getVehiclesByRouteTag(routeTag);
+        ArrayList<Vehicle> dirVehicles = new ArrayList<>();
+
+        for (Vehicle vehicle : routeVehicles) {
+            if (vehicle.getDirectionTag().equals(dirTag)) {
+                dirVehicles.add(vehicle);
+            }
+        }
+
+        return new VehicleLocationsOutputData(dirVehicles);
     }
 }

--- a/backend/src/main/java/com/example/backend/use_case/vehicle_locations/VehicleLocationsService.java
+++ b/backend/src/main/java/com/example/backend/use_case/vehicle_locations/VehicleLocationsService.java
@@ -2,6 +2,6 @@ package com.example.backend.use_case.vehicle_locations;
 
 public interface VehicleLocationsService {
 
-    VehicleLocationsOutputData execute(String routeTag);
+    VehicleLocationsOutputData execute(String routeTag, String dirTag);
 
 }

--- a/backend/src/test/java/com/example/backend/use_case/vehicle_locations/VehicleLocationsImplementationTest.java
+++ b/backend/src/test/java/com/example/backend/use_case/vehicle_locations/VehicleLocationsImplementationTest.java
@@ -1,0 +1,94 @@
+package com.example.backend.use_case.vehicle_locations;
+
+import com.example.backend.data_access.vehicle.VehicleDataAccessInterface;
+import com.example.backend.entity.Vehicle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class VehicleLocationsImplementationTest {
+
+    @Mock
+    private VehicleDataAccessInterface vehicleDAO;
+
+    @InjectMocks
+    private VehicleLocationsImplementation vehicleLocationsImplementation;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        Vehicle mockVehicle = new Vehicle(0, 100, 0.0f, 0.0f, 0, "dirTag");
+
+        ArrayList<Vehicle> mockVehicles = new ArrayList<>();
+
+        mockVehicles.add(mockVehicle);
+
+        when(vehicleDAO.getVehiclesByRouteTag("nonemptyVehicles")).thenReturn(mockVehicles);
+        when(vehicleDAO.getVehiclesByRouteTag("emptyVehicles")).thenReturn(new ArrayList<>());
+    }
+
+    @Test
+    void execute_ReturnsVehicleLocationsOutputData_WhenVehiclesExist() {
+        // Arrange
+        String routeTag = "nonemptyVehicles";
+        String dirTag = "dirTag";
+
+        // Act
+        VehicleLocationsOutputData result = vehicleLocationsImplementation.execute(routeTag, dirTag);
+
+        // Assert
+        assert(!result.getVehicles().isEmpty());
+    }
+
+    @Test
+    void execute_ReturnsVehicleLocationsOutputData_WhenNoDirTagVehiclesExist() {
+        // Arrange
+        String routeTag = "nonemptyVehicles";
+        String dirTag = "wrongDirTag";
+
+        // Act
+        VehicleLocationsOutputData result = vehicleLocationsImplementation.execute(routeTag, dirTag);
+
+        // Assert
+        assert(result.getVehicles().isEmpty());
+    }
+
+    @Test
+    void execute_ReturnsEmptyVehicleLocationsOutputData_WhenNoVehiclesExist() {
+        // Arrange
+        String routeTag = "emptyVehicles";
+        String dirTag = "dirTag";
+
+        when(vehicleDAO.getVehiclesByRouteTag(anyString())).thenReturn(new ArrayList<>());
+
+        // Act
+        VehicleLocationsOutputData result = vehicleLocationsImplementation.execute(routeTag, dirTag);
+
+        // Assert
+        assert(result.getVehicles().isEmpty());
+    }
+
+    @Test
+    void execute_ReturnsEmptyVehicleLocationsOutputData_WhenRouteDoesntExist() {
+        // Arrange
+        String routeTag = "wrongRouteTag";
+        String dirTag = "dirTag";
+
+        when(vehicleDAO.getVehiclesByRouteTag(anyString())).thenReturn(new ArrayList<>());
+
+        // Act
+        VehicleLocationsOutputData result = vehicleLocationsImplementation.execute(routeTag, dirTag);
+
+        // Assert
+        assert(result.getVehicles().isEmpty());
+    }
+
+}


### PR DESCRIPTION
# Pull Request: Update Vehicle Locations Use Case to Accept `dirTag` Parameter

## Issue
Closes #58

## Description
This pull request addresses the issue of enhancing the Vehicle Locations use case by allowing it to accept an additional `dirTag` parameter for more targeted vehicle information.

## Changes Made
- Updated `VehicleLocationsController` to take in an additional `dirTag` parameter.
- Updated `VehicleLocationsService` to accept the new `dirTag` parameter.
- Modified `VehicleLocationsImplementation` to filter vehicles based on both `routeTag` and `dirTag`.
- Added comprehensive tests for the Vehicle Locations use case, covering various scenarios:
  - Case 1: Returns a nonempty list of Vehicles.
  - Case 2: Returns an empty list of Vehicles when no vehicles exist with the given `dirTag`.
  - Case 3: Returns an empty list of Vehicles when no vehicles exist for a given `routeTag`.
  - Case 4: Returns an empty list of Vehicles when the `routeTag` does not exist.

## Testing
- All new tests pass successfully.
- Existing tests remain unaffected.

## Reviewer Notes
Please pay attention to the modifications made in the `VehicleLocationsController`, `VehicleLocationsService`, and `VehicleLocationsImplementation` files. Additionally, review the new test cases to ensure they cover the mentioned scenarios effectively.

## Checklist
- [x] Code follows the project's coding standards.
- [x] All tests pass.
- [x] Documentation is updated.
- [x] The commit history is clean and follows best practices.
